### PR TITLE
Check prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 pcal-*.tar
 
+# Ignore temp vim files
+*.swp

--- a/lib/pcal.ex
+++ b/lib/pcal.ex
@@ -54,9 +54,11 @@ defmodule Pcal do
         case converter_exists?() do
           {:ok, converter_path} ->
             {:ok, %{command_path: command_path, converter_path: converter_path}}
+
           {:error, message} ->
             {:error, message}
         end
+
       {:error, message} ->
         {:error, message}
     end

--- a/lib/pcal.ex
+++ b/lib/pcal.ex
@@ -37,4 +37,28 @@ defmodule Pcal do
       _ -> {:error, "can not find executable #{@pdf_converter_command}."}
     end
   end
+
+  @doc """
+  Check prerequisites
+
+  ## Exampless
+
+      iex> Pcal.prerequisites?
+      {:ok, %{command_path: "/usr/bin/pcal", converter_path: "/usr/bin/ps2pdf"}}
+
+  """
+
+  def prerequisites? do
+    case command_exists?() do
+      {:ok, command_path} ->
+        case converter_exists?() do
+          {:ok, converter_path} ->
+            {:ok, %{command_path: command_path, converter_path: converter_path}}
+          {:error, message} ->
+            {:error, message}
+        end
+      {:error, message} ->
+        {:error, message}
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a function that returns the command to generate the ps file and the path of the ps2pdf converter.  In case of any of those, doesn't exist, is going to return an error and the corresponding message.